### PR TITLE
fix(header): read description delimiter exactly as ": "

### DIFF
--- a/lexer_state.go
+++ b/lexer_state.go
@@ -111,12 +111,13 @@ func descriptionDelimiterState(l *lexer) stateFunc {
 		l.Emit(breakingChangeToken)
 	}
 
-	l.Take(": ")
+	l.Next()
 
-	if l.Current() != ": " {
+	if l.Current() != ":" || l.Peek() != ' ' {
 		l.Error(errDescMissingDelimiter)
 		return nil
 	}
+	l.Next()
 
 	l.Emit(descDelimiterToken)
 

--- a/parser_header_test.go
+++ b/parser_header_test.go
@@ -17,6 +17,24 @@ func TestParseHeaderValid(t *testing.T) {
 		"feat: description with body 1, \n\n2, 3 and 4?",
 		"feat1234(@scope/scope1,scope2): description, \n\n body 1 2, 3 and 4?",
 		"1245#feat1234(@scope/scope1,scope2): description, \n\n body 1 2, 3 and 4?",
+		"feat: description with colon at the end: mid:dle and :start of words",
+		"feat: description with gitmoji at the end :hammer:",
+		"feat: description with gitmoji in :hammer: the middle",
+		"feat: :hammer: description with gitmoji at the start",
+		"feat(scope): description with colon at the end: mid:dle and :start of words",
+		"feat(scope): description with gitmoji at the end :hammer:",
+		"feat(scope): description with gitmoji in :hammer: the middle",
+		"feat(scope): :hammer: description with gitmoji at the start",
+		"feat!: description with colon at the end: mid:dle and :start of words",
+		"feat!: description with gitmoji at the end :hammer:",
+		"feat!: description with gitmoji in :hammer: the middle",
+		"feat!: :hammer: description with gitmoji at the start",
+		"feat(scope)!: description with colon at the end: mid:dle and :start of words",
+		"feat(scope)!: description with gitmoji at the end :hammer:",
+		"feat(scope)!: description with gitmoji in :hammer: the middle",
+		"feat(scope)!: :hammer: description with gitmoji at the start",
+		`feat: : : A description`,
+		`feat: :: A description ::`,
 	}
 
 	p := New()
@@ -52,6 +70,8 @@ func TestParseHeaderInvalid(t *testing.T) {
 		`feat((`,
 		`feat():`,
 		`feat):`,
+		`feat:: A description`,
+		`feat:::: A description`,
 	}
 
 	p := New()


### PR DESCRIPTION
This fixes an issue where a commit header like
this: `type(scope): :bulb: look a light bulb!` will case an error. `lexer.Take()` is greedy and will read `: :` into the `Current()` token and thus will fail the comparison to the expected delimiter (`: `).

fixes: conventionalcommit/commitlint#15